### PR TITLE
fix: URL as APINamespace

### DIFF
--- a/src/callAPIMethod.js
+++ b/src/callAPIMethod.js
@@ -19,9 +19,9 @@ export function getAPIPrefix(APINamespace) {
     return reAbsolute.test(APINamespace) ? APINamespace : '/' + APINamespace;
 }
 
-function getFullPath(APINamespace, namespace, path=[]) {
+export function getFullPath(APINamespace, namespace, path=[]) {
     path = [].concat(path);
-    return uri.join(getAPIPrefix(APINamespace), namespace, ...path);
+    return uri.join(getAPIPrefix(APINamespace), namespace, ...path).replace(':/', '://');
 }
 
 function callAPI(APINamespace, fetchOptions, namespace = '', { path=[], query={}, options={}, method='json' }) {

--- a/test/callAPIMethod.spec.js
+++ b/test/callAPIMethod.spec.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { getAPIPrefix } from '../src/callAPIMethod';
+import { getAPIPrefix, getFullPath } from '../src/callAPIMethod';
 
 test('getAPIPrefix', t => {
     t.is(getAPIPrefix('api'), '/api', 'relative path');
@@ -7,4 +7,13 @@ test('getAPIPrefix', t => {
     t.is(getAPIPrefix('http://api.example.com'), 'http://api.example.com', 'http url');
     t.is(getAPIPrefix('https://api.example.com'), 'https://api.example.com', 'http url');
     t.is(getAPIPrefix('//api.example.com'), '//api.example.com', 'protocol-less url');
+    t.is(getAPIPrefix('https://localhost:8080'), 'https://localhost:8080', 'localhost');
+});
+
+test('getFullPath', t => {
+    t.is(getFullPath('api'), '/api', 'relative path');
+    t.is(getFullPath('/api'), '/api', 'absolute path');
+    t.is(getFullPath('http://example.com', '/test'), 'http://example.com/test', 'url');
+    t.is(getFullPath('http://example.com///', '/test/'), 'http://example.com/test/', 'url with slashes');
+    t.is(getFullPath('https://localhost:8080', '/test///'), 'https://localhost:8080/test/', 'localhost');
 });


### PR DESCRIPTION
when URL is used as APINamespace, one slash is missing due to uri.join from unity-utils dropping consecutive slashes