### PR TITLE
feat(fetch): add cancel callback to fetch calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm i --save unity-api
 ```
 
 # API
-## createAPI(resources, middleware, namespace, fetchOptions);
+## createAPI(resources, middleware, namespace, fetchOptions, cancelNamespace);
 
 **Returns:** {Object}
 
@@ -169,6 +169,12 @@ Usually you would want to proxy api calls from the SPA to the backend using some
 ```
 
 API-wide default `fetch` [options](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch#Parameters).
+
+### cancelNamespace {String} *Optional*
+
+**Default:** `'CANCEL'`
+
+You can call `API[resource][method](methodParams, middlewareOptions, responseOptions)[cancelNamespace]` to cancel fetch call.
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "node": ">=8.10.0"
   },
   "dependencies": {
+    "abortcontroller-polyfill": "^1.1.9",
     "isomorphic-fetch": "^2.2.1",
     "unity-utils": "^1.0.1",
     "url": "^0.11.0"

--- a/src/createAPI.js
+++ b/src/createAPI.js
@@ -6,7 +6,8 @@ const createAPI = (
     resources = {},
     middleware = [],
     APINamespace,
-    fetchOptions
+    fetchOptions,
+    cancelNamespace = 'CANCEL'
 ) => Object.keys(resources).reduce( (api, resourceId) => {
     api[resourceId] = Object.keys(resources[resourceId].methods)
         .reduce( (resource, method) => {
@@ -25,7 +26,8 @@ const createAPI = (
                     methodOptions,
                     apiParams,
                     resourceId,
-                    method
+                    method,
+                    cancelNamespace
                 );
             };
             return resource;

--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import sinon from 'sinon';
 import applyMiddleware from '../src/applyMiddleware';
+import { abort } from '../src/callAPIMethod';
 
 const noop = _ => _;
 
@@ -40,8 +41,9 @@ test('one middleware', t => {
     const params = { params: 'params' };
     const resourceId = 'resourceId';
     const method = 'method';
+    const cancelNamespace = 'CANCEL';
 
-    t.deepEqual(applyMiddleware(applyTo, [ middleware ], options, params, resourceId, method), params);
+    t.deepEqual(applyMiddleware(applyTo, [ middleware ], options, params, resourceId, method), params, cancelNamespace);
     t.true(applyTo.calledOnce);
     t.true(applyTo.calledWithExactly(params, options, params, resourceId, method));
     t.true(middleware.calledOnce);

--- a/test/callAPIMethod.spec.js
+++ b/test/callAPIMethod.spec.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
+import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import callAPIMethod from '../src/callAPIMethod';
 import APIError from '../src/error';
 
@@ -39,7 +40,12 @@ test.serial('default params', async t => {
     await callAPIMethod();
 
     t.is(fetchMock.lastUrl(matcher), '/api', 'correct url');
-    t.deepEqual(fetchMock.lastOptions(matcher), {
+
+    const result = fetchMock.lastOptions(matcher);
+
+    delete result.signal;
+
+    t.deepEqual(result, {
         cache: 'default',
         credentials: 'include',
         method: 'GET',
@@ -148,6 +154,11 @@ test.serial('fetch options', async t => {
     await callAPIMethod(APINamespace, fetchOptions, namespace, responseOptions, methodOptions);
 
     t.is(fetchMock.lastUrl(matcher), '/rest-api/user/path?edit=true', 'correct url');
+
+    let result = fetchMock.lastOptions(matcher);
+
+    delete result.signal;
+
     t.deepEqual(fetchMock.lastOptions(matcher), {
         cache: 'default',
         credentials: 'omit',
@@ -166,7 +177,12 @@ test.serial('fetch options', async t => {
     await callAPIMethod(APINamespace, fetchOptions, namespace, responseOptions, newMethodOptions);
 
     t.true(spyResponse200Json.calledOnce);
-    t.deepEqual(fetchMock.lastOptions(matcher), {
+
+    result = fetchMock.lastOptions(matcher);
+
+    delete result.signal;
+
+    t.deepEqual(result, {
         cache: 'default',
         credentials: 'omit',
         method: 'POST',
@@ -181,7 +197,7 @@ test.serial('fetch options', async t => {
 });
 
 test.serial('unsupported Response method', async t => {
-    fetchMock.get(matcher, Response200);
+    fetchMock.get(matcher, Response200, { overwriteRoutes: false });
 
     const APINamespace = 'rest-api';
     const namespace = 'user';
@@ -205,7 +221,7 @@ test.serial('unsupported Response method', async t => {
 });
 
 test.serial('returns full response object', async t => {
-    fetchMock.get(matcher, Response200);
+    fetchMock.get(matcher, Response200, { overwriteRoutes: false });
 
     const APINamespace = 'rest-api';
     const namespace = 'user';


### PR DESCRIPTION
That's not ideal solution. AbortController is placed in callAPI attribute and it's each next call will be replaced with new one. And if you call that abort function you will abort the last one fetch call and that's not what you expect.

I thought how to mark calls and the easiest decision is to pass some x-request-id into headers of fetch call and use it to store AbortControllers into some hash with request-id keys.
Do you have any pros/cons or any other ideas how to mark any fetch call?